### PR TITLE
fix infinite cycle when Exclude Duplicate option was selected

### DIFF
--- a/pass-gen/script-pass.js
+++ b/pass-gen/script-pass.js
@@ -85,7 +85,6 @@ const getUserOptions = () => {
     return Array.from(passOptions).filter(option => option.checked).map(option => option.name);
 }
 
-// TODO: Fix bug where app is blocked when exclude duplicates is checked
 const generatePassword = (length) => {
     let password = '';
     let selectedCharSet = getUserOptions().map(option => charSet[option]).join('');
@@ -97,11 +96,13 @@ const generatePassword = (length) => {
         return;
     }
 
-    for(let i = 0; i < length; i++) {
+    for(let i = 0; i < length && selectedCharSet.length > 0; i++) {
         let newChar = getRandomChar(selectedCharSet);
         if (excludeDuplicates) {
-            while (password.includes(newChar)) {
+            let cycle = 0;
+            while (password.includes(newChar) && cycle < 5) {
                 newChar = getRandomChar(selectedCharSet);
+                cycle++;
             }
         }
         if (includeSpaces) {


### PR DESCRIPTION
There were two scenarios
1. When no options were provided
2. When the available characters were less than the password length required